### PR TITLE
Add new `entitySchema` field and refactor callsites of `entityDB` to use `getEntityDBName` instead

### DIFF
--- a/persistent-redis/Database/Persist/Redis/Internal.hs
+++ b/persistent-redis/Database/Persist/Redis/Internal.hs
@@ -23,10 +23,10 @@ toLabel :: FieldDef -> B.ByteString
 toLabel = U.fromString . unpack . unFieldNameDB . fieldDB
 
 toEntityString :: PersistEntity val => val -> Text
-toEntityString = unEntityNameDB . entityDB . entityDef . Just
+toEntityString = unEntityNameDB . getEntityDBName . entityDef . Just
 
 toEntityName :: EntityDef -> B.ByteString
-toEntityName = U.fromString . unpack . unEntityNameDB . entityDB
+toEntityName = U.fromString . unpack . unEntityNameDB . getEntityDBName
 
 mkEntity :: (MonadFail m, PersistEntity val) => Key val -> [(B.ByteString, B.ByteString)] -> m (Entity val)
 mkEntity key fields = do

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -712,6 +712,8 @@ mkUnboundEntityDef ps parsedEntDef =
                     case parsedEntityDefComments parsedEntDef of
                         [] -> Nothing
                         comments -> Just (T.unlines comments)
+                , -- TODO: start parsing the schema attribute and write it here.
+                  entitySchema = Nothing
                 }
         }
   where

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -335,7 +335,7 @@ liftAndFixKeys mps emEntities entityMap unboundEnt =
             |]
           where
             fixForeignRefTableDBName =
-                entityDB (unboundEntityDef parentDef)
+                getEntityDBName (unboundEntityDef parentDef)
             foreignFieldNames =
                 case unboundForeignFields of
                     FieldListImpliedId ffns ->
@@ -1968,7 +1968,7 @@ fromValues entDef funName constructExpr fields = do
     return [ suc, normalClause [VarP x] patternMatchFailure ]
   where
     tableName =
-        unEntityNameDB (entityDB (unboundEntityDef entDef))
+        unEntityNameDB (getEntityDBName (unboundEntityDef entDef))
     patternSuccess =
         case fields of
             [] -> do

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -153,6 +153,8 @@ data EntityDef = EntityDef
     -- ^ Whether or not this entity represents a sum type in the database.
     , entityComments :: !(Maybe Text)
     -- ^ Optional comments on the entity.
+    , entitySchema :: !(Maybe Text)
+    -- ^ The schema the entity belongs to.
     --
     -- @since 2.10.0
     }


### PR DESCRIPTION
See ticket https://linear.app/mercury/issue/INT-843/hackday-persistent-schemas-refactor-persistent-library-to-always-use