### PR TITLE
revert change to `getEntityDBName`

### DIFF
--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -84,9 +84,7 @@ getEntityHaskellName = entityHaskell
 getEntityDBName
     :: EntityDef
     -> EntityNameDB
-getEntityDBName entityDef = case entitySchema entityDef of
-    Nothing -> entityDB entityDef
-    Just schema -> EntityNameDB $ schema <> "." <> unEntityNameDB (entityDB entityDef)
+getEntityDBName = entityDB
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra


### PR DESCRIPTION
We realized that this strategy is too simplistic, we have to go into the implementation-specific libraries and change how they generate the table identifier.