### PR TITLE
add setters and getters for `entitySchema`

### DIFF
--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -19,6 +19,7 @@ module Database.Persist.EntityDef
     , getEntityKeyFields
     , getEntityComments
     , getEntityExtra
+    , getEntitySchema
     , isEntitySum
     , entityPrimary
     , entitiesPrimary
@@ -27,6 +28,7 @@ module Database.Persist.EntityDef
     , setEntityId
     , setEntityIdDef
     , setEntityDBName
+    , setEntitySchema
     , overEntityFields
       -- * Related Types
     , EntityIdDef(..)
@@ -88,6 +90,9 @@ getEntityDBName = entityDB
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra
+
+getEntitySchema :: EntityDef -> Maybe SchemaName
+getEntitySchema = entitySchema
 
 -- |
 --
@@ -194,6 +199,9 @@ getEntityKeyFields = entityKeyFields
 -- @since 2.13.0.0
 setEntityFields :: [FieldDef] -> EntityDef -> EntityDef
 setEntityFields fd ed = ed { entityFields = fd }
+
+setEntitySchema :: Maybe SchemaName -> EntityDef -> EntityDef
+setEntitySchema sn ed = ed { entitySchema = sn }
 
 -- | Perform a mapping function over all of the entity fields, as determined by
 -- 'getEntityFieldsDatabase'.


### PR DESCRIPTION
This follows the existing library convention to have getters and setters on `EntityDef` fields.