### PR TITLE
Start using table schema in queries with Postgres

### DIFF
--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1392,8 +1392,8 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
-                            , foreignRefSchemaName =
-                                SchemaNameDB $ psToDBName ps refSchemaName
+                            , -- TODO: verify that this is correct.
+                              foreignRefSchemaDBName = Nothing
                             , foreignConstraintNameHaskell =
                                 constraintName
                             , foreignConstraintNameDBName =

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1392,8 +1392,14 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
-                            , -- TODO: verify that this is correct.
-                              foreignRefSchemaDBName = Nothing
+                            , -- TODO: The existing foreign key syntax for
+                              -- UnboundForeignDef is not sufficiently rich to
+                              -- allow specifying the schema of the foreign
+                              -- relation. We need to add the ability to parse
+                              -- schema=foo directives inline for foreign keys
+                              -- and insert those values here.
+                              foreignRefSchemaDBName =
+                                Nothing
                             , foreignConstraintNameHaskell =
                                 constraintName
                             , foreignConstraintNameDBName =

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1392,6 +1392,8 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
+                            , foreignRefSchemaName =
+                                SchemaNameDB $ psToDBName ps refSchemaName
                             , foreignConstraintNameHaskell =
                                 constraintName
                             , foreignConstraintNameDBName =

--- a/persistent/Database/Persist/Sql/Internal.hs
+++ b/persistent/Database/Persist/Sql/Internal.hs
@@ -161,8 +161,8 @@ mkColumns allDefs t overrides =
     mkColumnReference :: FieldDef -> Maybe ColumnReference
     mkColumnReference fd =
         fmap
-            (\(tName, cName) ->
-                ColumnReference tName cName $ overrideNothings $ fieldCascade fd
+            (\(tName, sName, cName) ->
+                ColumnReference tName sName cName $ overrideNothings $ fieldCascade fd
             )
         $ ref (fieldDB fd) (fieldReference fd) (fieldAttrs fd)
 
@@ -178,20 +178,21 @@ mkColumns allDefs t overrides =
     ref :: FieldNameDB
         -> ReferenceDef
         -> [FieldAttr]
-        -> Maybe (EntityNameDB, ConstraintNameDB) -- table name, constraint name
-    ref c fe []
-        | ForeignRef f <- fe =
-            Just (resolveTableName allDefs f, refNameFn tableName c)
-        | otherwise = Nothing
-    ref _ _ (FieldAttrNoreference:_) = Nothing
-    ref c fe (a:as) = case a of
-        FieldAttrReference x -> do
-            (_, constraintName) <- ref c fe as
-            pure (EntityNameDB  x, constraintName)
-        FieldAttrConstraint x -> do
-            (tableName_, _) <- ref c fe as
-            pure (tableName_, ConstraintNameDB x)
-        _ -> ref c fe as
+        -> Maybe (EntityNameDB, Maybe SchemaNameDB, ConstraintNameDB) -- table name, schema name, constraint name
+    ref = undefined
+    -- ref c fe []
+    --     | ForeignRef f <- fe =
+    --         Just (resolveTableName allDefs f, refNameFn tableName c)
+    --     | otherwise = Nothing
+    -- ref _ _ (FieldAttrNoreference:_) = Nothing
+    -- ref c fe (a:as) = case a of
+    --     FieldAttrReference x -> do
+    --         (_, constraintName) <- ref c fe as
+    --         pure (EntityNameDB  x, constraintName)
+    --     FieldAttrConstraint x -> do
+    --         (tableName_, _) <- ref c fe as
+    --         pure (tableName_, ConstraintNameDB x)
+    --     _ -> ref c fe as
 
 refName :: EntityNameDB -> FieldNameDB -> ConstraintNameDB
 refName (EntityNameDB table) (FieldNameDB column) =

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -39,6 +39,7 @@ data ColumnReference = ColumnReference
     -- ^ The table name that the
     --
     -- @since 2.11.0.0
+    , crSchemaName :: !(Maybe SchemaNameDB)
     , crConstraintName :: !ConstraintNameDB
     -- ^ The name of the foreign key constraint.
     --
@@ -137,4 +138,3 @@ defaultConnectionPoolConfig = ConnectionPoolConfig 1 600 10
 -- processing).
 newtype Single a = Single {unSingle :: a}
     deriving (Eq, Ord, Show, Read)
-

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -554,7 +554,7 @@ type ForeignFieldDef = (FieldNameHS, FieldNameDB)
 data ForeignDef = ForeignDef
     { foreignRefTableHaskell       :: !EntityNameHS
     , foreignRefTableDBName        :: !EntityNameDB
-    , foreignRefSchemaName         :: !SchemaNameDB
+    , foreignRefSchemaDBName       :: !(Maybe SchemaNameDB)
     , foreignConstraintNameHaskell :: !ConstraintNameHS
     , foreignConstraintNameDBName  :: !ConstraintNameDB
     , foreignFieldCascade          :: !FieldCascade

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -554,6 +554,7 @@ type ForeignFieldDef = (FieldNameHS, FieldNameDB)
 data ForeignDef = ForeignDef
     { foreignRefTableHaskell       :: !EntityNameHS
     , foreignRefTableDBName        :: !EntityNameDB
+    , foreignRefSchemaName         :: !SchemaNameDB
     , foreignConstraintNameHaskell :: !ConstraintNameHS
     , foreignConstraintNameDBName  :: !ConstraintNameDB
     , foreignFieldCascade          :: !FieldCascade


### PR DESCRIPTION
I tested this PR by hardcoding `entitySchema = Just $ SchemaNameDB "foo"`, and it broke the Postgres test suite with the error message "schema foo not found". This means that the schema we specify is making it into the queries we dispatch.