### PR TITLE
update sqlQQ test to consider a case with a schema

### DIFF
--- a/persistent-qq/test/PersistentTestModels.hs
+++ b/persistent-qq/test/PersistentTestModels.hs
@@ -110,10 +110,16 @@ share
     ~no Int
     def Int
 
+  PetAnimal schema=animals
+    ownerId PersonId
+    name Text
 |]
 
 deriving instance Show (BackendKey backend) => Show (PetGeneric backend)
 deriving instance Eq (BackendKey backend) => Eq (PetGeneric backend)
+
+deriving instance Show (BackendKey backend) => Show (PetAnimalGeneric backend)
+deriving instance Eq (BackendKey backend) => Eq (PetAnimalGeneric backend)
 
 share [ mkPersist sqlSettings { mpsPrefixFields = False, mpsGeneric = True }
       , mkMigrate "noPrefixMigrate"
@@ -178,3 +184,4 @@ cleanDB = do
   deleteWhere ([] :: [Filter (OutdoorPetGeneric backend)])
   deleteWhere ([] :: [Filter (UserPTGeneric backend)])
   deleteWhere ([] :: [Filter (EmailPTGeneric backend)])
+  deleteWhere ([] :: [Filter (PetAnimalGeneric backend)])

--- a/persistent-qq/test/Spec.hs
+++ b/persistent-qq/test/Spec.hs
@@ -120,12 +120,15 @@ spec = describe "persistent-qq" $ do
         personKey <- insert person
         let pet = PetAnimal personKey "Fluffy"
         petKey <- insert pet
-        let runQuery
+        let runQueryQuoted, runQueryRaw
               :: (RawSql a, Functor m, MonadIO m)
               => ReaderT SqlBackend m [a]
-            runQuery = [sqlQQ| SELECT ?? FROM ^{PetAnimal} |]
-        ret <- runQuery
-        liftIO $ ret @?= [Entity petKey pet]
+            runQueryQuoted = [sqlQQ| SELECT ?? FROM ^{PetAnimal} |]
+            runQueryRaw = [sqlQQ| SELECT ?? FROM animals.pet_animal |]
+        retQuoted <- runQueryQuoted
+        retRaw <- runQueryRaw
+        liftIO $ retQuoted @?= [Entity petKey pet]
+        liftIO $ retRaw @?= [Entity petKey pet]
 
     it "sqlQQ/OUTER JOIN" $ db $ do
         let insert' :: (PersistStore backend, PersistEntity val, PersistEntityBackend val ~ BaseBackend backend, MonadIO m, SafeToInsert val)

--- a/persistent-qq/test/Spec.hs
+++ b/persistent-qq/test/Spec.hs
@@ -115,6 +115,18 @@ spec = describe "persistent-qq" $ do
         liftIO $ ret1 @?= [Entity p1k p1]
         liftIO $ ret2 @?= [Entity (RFOKey $ unPersonKey p1k) (RFO p1)]
 
+    it "sqlQQ/entity in schema" $ db $ do
+        let person = Person "Zacarias" 93 Nothing
+        personKey <- insert person
+        let pet = PetAnimal personKey "Fluffy"
+        petKey <- insert pet
+        let runQuery
+              :: (RawSql a, Functor m, MonadIO m)
+              => ReaderT SqlBackend m [a]
+            runQuery = [sqlQQ| SELECT ?? FROM ^{PetAnimal} |]
+        ret <- runQuery
+        liftIO $ ret @?= [Entity petKey pet]
+
     it "sqlQQ/OUTER JOIN" $ db $ do
         let insert' :: (PersistStore backend, PersistEntity val, PersistEntityBackend val ~ BaseBackend backend, MonadIO m, SafeToInsert val)
                     => val -> ReaderT backend m (Key val, val)


### PR DESCRIPTION
It turns out that `sqlQQ` defers to the Persistent backend when generating table names, so if we fix all of those then sqlQQ should work with schemas.

This test suite depends on SQLite, which we haven't updated yet, but when we do, it will witness that sqlQQ is correctly interfacing with the backend when schemas are involved.