### PR TITLE
include entity and foreign field schema name parsing

### DIFF
--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -508,7 +508,7 @@ The above example is a "simple" foreign key. It refers directly to the Id column
 A pseudo formal syntax for @Foreign@ is:
 
 @
-Foreign $(TargetEntity) $(schema name) [$(cascade-actions)] $(constraint-name) $(columns) [ $(references) ]
+Foreign $(TargetEntity) [$(cascade-actions)] $(constraint-name) $(columns) [ $(references) ]
 
 columns := column0 [column1 column2 .. columnX]
 references := References $(target-columns)
@@ -553,12 +553,6 @@ We can specify delete/cascade behavior directly after the target table.
 @
 
 Now, if the email is deleted or updated, the user will be deleted or updated to match.
-
-Schema names can be specified between the target table and the constraint name.
-
-@
-    Foreign Email schema=some_schema OnDeleteCascade fk_user_email emailFirstPart emailSecondPart
-@
 
 === Non-Primary Key References
 

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -186,11 +186,21 @@ User sql=big_user_table
 This will alter the generated SQL to be:
 
 @
-CREATE TABEL big_user_table (
+CREATE TABLE big_user_table (
     id      SERIAL PRIMARY KEY,
     name    VARCHAR,
     age     INT
 );
+@
+
+= Table Schema
+
+You can use a @schema=some_schema@ annotation to specify the table's schema name.
+This can be placed before or after the entity's @sql=custom@ annotation, if it has one.
+
+@
+Foo schema=bar
+    baz        Int
 @
 
 = Customizing Types/Tables
@@ -498,7 +508,7 @@ The above example is a "simple" foreign key. It refers directly to the Id column
 A pseudo formal syntax for @Foreign@ is:
 
 @
-Foreign $(TargetEntity) [$(cascade-actions)] $(constraint-name) $(columns) [ $(references) ]
+Foreign $(TargetEntity) $(schema name) [$(cascade-actions)] $(constraint-name) $(columns) [ $(references) ]
 
 columns := column0 [column1 column2 .. columnX]
 references := References $(target-columns)
@@ -543,6 +553,12 @@ We can specify delete/cascade behavior directly after the target table.
 @
 
 Now, if the email is deleted or updated, the user will be deleted or updated to match.
+
+Schema names can be specified between the target table and the constraint name.
+
+@
+    Foreign Email schema=some_schema OnDeleteCascade fk_user_email emailFirstPart emailSecondPart
+@
 
 === Non-Primary Key References
 

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -310,6 +310,7 @@ parseLines ps = do
 data ParsedEntityDef = ParsedEntityDef
     { parsedEntityDefComments :: [Text]
     , parsedEntityDefEntityName :: EntityNameHS
+    , parsedEntityDefSchemaName :: Maybe SchemaNameDB
     , parsedEntityDefIsSum :: Bool
     , parsedEntityDefEntityAttributes :: [Attr]
     , parsedEntityDefFieldAttributes :: [[Token]]
@@ -329,6 +330,7 @@ toParsedEntityDef :: LinesWithComments -> ParsedEntityDef
 toParsedEntityDef lwc = ParsedEntityDef
     { parsedEntityDefComments = lwcComments lwc
     , parsedEntityDefEntityName = entNameHS
+    , parsedEntityDefSchemaName = schemaName
     , parsedEntityDefIsSum = isSum
     , parsedEntityDefEntityAttributes = entAttribs
     , parsedEntityDefFieldAttributes = attribs
@@ -348,6 +350,9 @@ toParsedEntityDef lwc = ParsedEntityDef
 
     (attribs, extras) =
         parseEntityFields fieldLines
+
+    schemaName =
+      fmap SchemaNameDB $ listToMaybe $ mapMaybe (T.stripPrefix "schema=") entAttribs
 
 isDocComment :: Token -> Maybe Text
 isDocComment tok =
@@ -712,8 +717,7 @@ mkUnboundEntityDef ps parsedEntDef =
                     case parsedEntityDefComments parsedEntDef of
                         [] -> Nothing
                         comments -> Just (T.unlines comments)
-                , -- TODO: start parsing the schema attribute and write it here.
-                  entitySchema = Nothing
+                , entitySchema = parsedEntityDefSchemaName parsedEntDef
                 }
         }
   where
@@ -1392,12 +1396,6 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
-                            , -- TODO: The existing foreign key syntax for
-                              -- UnboundForeignDef is not sufficiently rich to
-                              -- allow specifying the schema of the foreign
-                              -- relation. We need to add the ability to parse
-                              -- schema=foo directives inline for foreign keys
-                              -- and insert those values here.
                               foreignRefSchemaDBName =
                                 Nothing
                             , foreignConstraintNameHaskell =

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -59,7 +59,7 @@ import Data.List (find, foldl')
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isNothing, isJust, listToMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid (mappend)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -1382,11 +1382,11 @@ takeForeign ps entityName = takeRefTable
     takeRefTable [] =
         error $ errorPrefix ++ " expecting foreign table name"
     takeRefTable (refTableName:restLine) =
-        go restLine Nothing Nothing Nothing
+        go restLine Nothing Nothing
       where
-        go :: [Text] -> Maybe SchemaNameDB -> Maybe CascadeAction -> Maybe CascadeAction -> UnboundForeignDef
-        go (constraintNameText:rest) schemaName onDelete onUpdate
-            | isConstraintName =
+        go :: [Text] -> Maybe CascadeAction -> Maybe CascadeAction -> UnboundForeignDef
+        go (constraintNameText:rest) onDelete onUpdate
+            | not (T.null constraintNameText) && isLower (T.head constraintNameText) =
                 UnboundForeignDef
                     { unboundForeignFields =
                         either error id $ mkUnboundForeignFieldList foreignFields parentFields
@@ -1396,8 +1396,9 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
-                              foreignRefSchemaDBName =
+                            , foreignRefSchemaDBName =
                                 Nothing
+                            -- ^ This will be determined in the TH phase ('fixForeignRefSchemaDBName').
                             , foreignConstraintNameHaskell =
                                 constraintName
                             , foreignConstraintNameDBName =
@@ -1418,10 +1419,6 @@ takeForeign ps entityName = takeRefTable
                             }
                     }
           where
-            isConstraintName = not (T.null constraintNameText)
-              && isLower (T.head constraintNameText)
-              && isNothing (parseSchemaName constraintNameText)
-
             constraintName =
                 ConstraintNameHS constraintNameText
 
@@ -1443,30 +1440,21 @@ takeForeign ps entityName = takeRefTable
                                     , show plen, " parent fields"
                                     ]
 
-        go ((parseSchemaName -> Just schemaName) : rest) schemaName' onDelete onUpdate
-            | isJust schemaName' = error $ errorPrefix ++ "found more than one schema definition"
-            | otherwise = go rest (Just schemaName) onDelete onUpdate
-
-        go ((parseCascadeAction CascadeDelete -> Just cascadingAction) : rest) schemaName onDelete' onUpdate =
+        go ((parseCascadeAction CascadeDelete -> Just cascadingAction) : rest) onDelete' onUpdate =
             case onDelete' of
                 Nothing ->
-                    go rest schemaName (Just cascadingAction) onUpdate
+                    go rest (Just cascadingAction) onUpdate
                 Just _ ->
                     error $ errorPrefix ++ "found more than one OnDelete actions"
 
-        go ((parseCascadeAction CascadeUpdate -> Just cascadingAction) : rest) schemaName onDelete onUpdate' =
+        go ((parseCascadeAction CascadeUpdate -> Just cascadingAction) : rest) onDelete onUpdate' =
             case onUpdate' of
                 Nothing ->
-                    go rest schemaName onDelete (Just cascadingAction)
+                    go rest onDelete (Just cascadingAction)
                 Just _ ->
                     error $ errorPrefix ++ "found more than one OnUpdate actions"
 
-        go xs _ _ _ = error $ errorPrefix ++ "expecting a lower case constraint name, schema name, or a cascading action xs=" ++ show xs
-
-parseSchemaName :: Text -> Maybe SchemaNameDB
-parseSchemaName schemaNameText
-  | ["", schemaName] <- T.splitOn "schema=" schemaNameText = Just $ SchemaNameDB schemaName
-  | otherwise = Nothing
+        go xs _ _ = error $ errorPrefix ++ "expecting a lower case constraint name or a cascading action xs=" ++ show xs
 
 toFKConstraintNameDB :: PersistSettings -> EntityNameHS -> ConstraintNameHS -> ConstraintNameDB
 toFKConstraintNameDB ps entityName constraintName =

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -331,11 +331,15 @@ liftAndFixKeys mps emEntities entityMap unboundEnt =
                     $(lift fixForeignNullable)
                 , foreignRefTableDBName =
                     $(lift fixForeignRefTableDBName)
+                , foreignRefSchemaDBName =
+                    $(lift fixForeignRefSchemaDBName)
                 }
             |]
           where
             fixForeignRefTableDBName =
                 getEntityDBName (unboundEntityDef parentDef)
+            fixForeignRefSchemaDBName = 
+                getEntitySchema (unboundEntityDef parentDef)
             foreignFieldNames =
                 case unboundForeignFields of
                     FieldListImpliedId ffns ->

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -258,7 +258,7 @@ Bicycle -- | this is a bike
         baz
     deriving Eq
 -- | This is a Car
-Car
+Car schema=transportation
     -- | the make of the Car
     make String
     -- | the model of the Car
@@ -284,8 +284,13 @@ Car
 
         it "should parse the `entityAttrs` field" $ do
             entityAttrs (unboundEntityDef bicycle) `shouldBe` ["-- | this is a bike"]
-            entityAttrs (unboundEntityDef car) `shouldBe` []
+            entityAttrs (unboundEntityDef car) `shouldBe` ["schema=transportation"]
             entityAttrs (unboundEntityDef vehicle) `shouldBe` []
+
+        it "should parse the `entitySchema` field" $ do
+            entitySchema (unboundEntityDef bicycle) `shouldBe` Nothing
+            entitySchema (unboundEntityDef car) `shouldBe` (Just $ SchemaNameDB "transportation")
+            entitySchema (unboundEntityDef vehicle) `shouldBe` Nothing
 
         it "should parse the `unboundEntityFields` field" $ do
             let simplifyField field =
@@ -332,6 +337,7 @@ Notification
                 [ ForeignDef
                     { foreignRefTableHaskell = EntityNameHS "User"
                     , foreignRefTableDBName = EntityNameDB "user"
+                    , foreignRefSchemaDBName = Nothing
                     , foreignConstraintNameHaskell = ConstraintNameHS "fk_noti_user"
                     , foreignConstraintNameDBName = ConstraintNameDB "notificationfk_noti_user"
                     , foreignFieldCascade = FieldCascade Nothing Nothing

--- a/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
+++ b/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
@@ -85,7 +85,7 @@ ParentExplicit
 
 ChildExplicit
     name Text
-    Foreign ParentExplicit OnDeleteCascade OnUpdateCascade fkparent name
+    Foreign ParentExplicit schema=kids OnDeleteCascade OnUpdateCascade fkparent name
 |]
 
 spec :: Spec
@@ -101,6 +101,15 @@ spec = describe "ForeignRefSpec" $ do
 
     it "should compile" $ do
         True `shouldBe` True
+
+    describe "ForeignSchemaName" $ do
+        let
+            [childForeignDef] =
+                entityForeigns $ entityDef $ Proxy @ChildExplicit
+        it "should have a schema name defined" $ do
+            (foreignRefSchemaDBName childForeignDef)
+                `shouldBe`
+                    (Just $ SchemaNameDB "kids")
 
     describe "ForeignPrimarySource" $ do
         let

--- a/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
+++ b/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
@@ -49,6 +49,7 @@ mkPersist sqlSettings [persistLowerCase|
 
 HasCustomName sql=custom_name
     name Text
+    Primary name
 
 ForeignTarget
     name Text
@@ -79,13 +80,13 @@ ChildImplicit
     name Text
     parent ParentImplicitId OnDeleteCascade OnUpdateCascade
 
-ParentExplicit
+ParentExplicit schema=adult
     name Text
     Primary name
 
 ChildExplicit
     name Text
-    Foreign ParentExplicit schema=kids OnDeleteCascade OnUpdateCascade fkparent name
+    Foreign ParentExplicit OnDeleteCascade OnUpdateCascade fkparent name
 |]
 
 spec :: Spec
@@ -101,15 +102,6 @@ spec = describe "ForeignRefSpec" $ do
 
     it "should compile" $ do
         True `shouldBe` True
-
-    describe "ForeignSchemaName" $ do
-        let
-            [childForeignDef] =
-                entityForeigns $ entityDef $ Proxy @ChildExplicit
-        it "should have a schema name defined" $ do
-            (foreignRefSchemaDBName childForeignDef)
-                `shouldBe`
-                    (Just $ SchemaNameDB "kids")
 
     describe "ForeignPrimarySource" $ do
         let
@@ -185,3 +177,12 @@ spec = describe "ForeignRefSpec" $ do
                             , "got: "
                             , show as
                             ]
+
+    describe "Foreign Schema Name" $ do
+        let
+            [childForeignDef] =
+                entityForeigns $ entityDef $ Proxy @ChildExplicit
+        it "should have the correct schema name" $ do
+            (foreignRefSchemaDBName childForeignDef)
+                `shouldBe`
+                    (Just $ SchemaNameDB "adult")

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -85,7 +85,7 @@ Person json
     address Address
     deriving Show Eq
 
-HasSimpleCascadeRef
+HasSimpleCascadeRef schema=cascade
     person PersonId OnDeleteCascade
     deriving Show Eq
 
@@ -346,7 +346,7 @@ spec = describe "THSpec" $ do
                                     , fieldGenerated = Nothing
                                     , fieldIsImplicitIdColumn = True
                                     }
-                            , entityAttrs = []
+                            , entityAttrs = ["schema=cascade"]
                             , entityFields =
                                 [ FieldDef
                                     { fieldHaskell = FieldNameHS "person"
@@ -371,7 +371,7 @@ spec = describe "THSpec" $ do
                             , entityExtra = mempty
                             , entitySum = False
                             , entityComments = Nothing
-                            , entitySchema = Nothing
+                            , entitySchema = Just $ SchemaNameDB "cascade"
                             }
         it "has the cascade on the field def" $ do
             fieldCascade subject `shouldBe` expected


### PR DESCRIPTION
Adding support for `schema=schema_name` to be added to Persistent entity syntax so that the quasiquoter can generate schema specifications for entities or their foreign key fields (when using the complex `Foreign` keyword).