### PR TITLE
Update SQLite to make use of schemas

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -681,7 +681,11 @@ sqlForeign fdef = T.concat $
     , " FOREIGN KEY("
     , T.intercalate "," $ map (escapeF . snd. fst) $ foreignFields fdef
     , ") REFERENCES "
-    , escapeES (foreignRefTableDBName fdef) (foreignRefSchemaDBName fdef)
+    , -- It's a syntax error in SQLite to use a dot-qualified table name.
+      -- In general, it's not possible for SQLite to maintain foreign key
+      -- constraints across databases (which Persistent calls "schemas").
+      -- So we omit the schema here.
+      escapeE (foreignRefTableDBName fdef)
     , "("
     , T.intercalate "," $ map (escapeF . snd . snd) $ foreignFields fdef
     , ")"

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -881,8 +881,9 @@ checkForeignKeys = rawQuery query [] .| C.mapM parse
 
     query = T.unlines
         [ "SELECT origin.rowid, origin.\"table\", group_concat(foreignkeys.\"from\")"
-        , "FROM pragma_foreign_key_check() AS origin"
-        , "INNER JOIN pragma_foreign_key_list(origin.\"table\") AS foreignkeys"
+        , "FROM pragma_database_list() as databases"
+        , "INNER JOIN pragma_foreign_key_check(null, databases.name) AS origin"
+        , "INNER JOIN pragma_foreign_key_list(origin.\"table\", databases.name) AS foreignkeys"
         , "ON origin.fkid = foreignkeys.id AND origin.parent = foreignkeys.\"table\""
         , "GROUP BY origin.rowid"
         ]

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -857,7 +857,6 @@ data ForeignKeyViolation = ForeignKeyViolation
     , foreignKeyRowId :: Int64 -- ^ The ROWID of the row with the violated foreign key constraint
     } deriving (Eq, Ord, Show)
 
--- TODO: add database qualifier here
 -- | Outputs all (if any) the violated foreign key constraints in the database.
 --
 -- The main use is to validate that no foreign key constraints were

--- a/persistent-sqlite/test/SqliteInit.hs
+++ b/persistent-sqlite/test/SqliteInit.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module SqliteInit (
   (@/=), (@==), (==@)
@@ -103,7 +104,9 @@ runConn f = do
     let debugPrint = not travis && _debugOn
     let printDebug = if debugPrint then print . fromLogStr else void . return
     void $ flip runLoggingT (\_ _ _ s -> printDebug s) $ do
-        withSqlitePoolInfo sqlite_database 1 $ runSqlPool f
+        withSqlitePoolInfo sqlite_database 1 $ runSqlPool $ do
+          rawSql @(Single Int64) ("attach '" <> sqlite_foo_database_file <> "' as foo") []
+          f
 
 db :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
 db actions = do

--- a/persistent-sqlite/test/SqliteInit.hs
+++ b/persistent-sqlite/test/SqliteInit.hs
@@ -16,6 +16,7 @@ module SqliteInit (
   , db
   , sqlite_database
   , sqlite_database_file
+  , sqlite_foo_database_file
   , BackendKey(..)
   , GenerateKey(..)
 
@@ -90,6 +91,9 @@ type BackendMonad = SqlBackend
 sqlite_database_file :: Text
 sqlite_database_file = "testdb.sqlite3"
 
+sqlite_foo_database_file :: Text
+sqlite_foo_database_file = "testdb-foo.sqlite3"
+
 sqlite_database :: SqliteConnectionInfo
 sqlite_database = mkSqliteConnectionInfo sqlite_database_file
 
@@ -104,4 +108,3 @@ runConn f = do
 db :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
 db actions = do
     runResourceT $ runConn $ actions >> transactionUndo
-

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -155,7 +154,6 @@ main = do
         $ removeFile $ fromText sqlite_database_file
     handle (\(_ :: IOException) -> return ())
         $ removeFile $ fromText sqlite_foo_database_file
-    runConn $ rawSql @(Single Int64) ("attach '" <> sqlite_foo_database_file <> "' as foo") []
 
     runConn $ do
         mapM_ setup

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -152,6 +153,9 @@ main :: IO ()
 main = do
     handle (\(_ :: IOException) -> return ())
         $ removeFile $ fromText sqlite_database_file
+    handle (\(_ :: IOException) -> return ())
+        $ removeFile $ fromText sqlite_foo_database_file
+    runConn $ rawSql @(Single Int64) ("attach '" <> sqlite_foo_database_file <> "' as foo") []
 
     runConn $ do
         mapM_ setup
@@ -177,6 +181,7 @@ main = do
             , MigrationColumnLengthTest.migration
             , TransactionLevelTest.migration
             , LongIdentifierTest.migration
+            , SchemaTest.migration
             , SchemaTest.migration
             ]
         PersistentTest.cleanDB

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -44,6 +44,7 @@ import qualified RawSqlTest
 import qualified ReadWriteTest
 import qualified Recursive
 import qualified RenameTest
+import qualified SchemaTest
 import qualified SumTypeTest
 import qualified TransactionLevelTest
 import qualified TypeLitFieldDefsTest
@@ -176,6 +177,7 @@ main = do
             , MigrationColumnLengthTest.migration
             , TransactionLevelTest.migration
             , LongIdentifierTest.migration
+            , SchemaTest.migration
             ]
         PersistentTest.cleanDB
         ForeignKey.cleanDB
@@ -244,6 +246,7 @@ main = do
         MigrationTest.specsWith db
         LongIdentifierTest.specsWith db
         GeneratedColumnTestSQL.specsWith db
+        SchemaTest.specsWith db
 
         it "issue #328" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
             void $ runMigrationSilent migrateAll

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -23,8 +23,8 @@ cleanDB
 cleanDB = deleteWhere ([] :: [Filter (SchemaEntityGeneric backend)])
 
 specsWith
-    :: Runner backend m
-    => RunDb backend m
+    :: Runner SqlBackend m
+    => RunDb SqlBackend m
     -> Spec
 specsWith runConn = describe "entity with non-null schema" $
     it "inserts and selects work as expected" $ asIO $ runConn $ do
@@ -33,5 +33,7 @@ specsWith runConn = describe "entity with non-null schema" $
             SchemaEntity
                 { schemaEntityFoo = 42
                 }
-        Just _ <- get x
+        Just schemaEntity <- get x
+        rawFoo  <- rawSql "SELECT foo FROM foo.schema_entity" []
+        liftIO $ rawFoo @?= [Single (42 :: Int)]
         return ()


### PR DESCRIPTION
This case is a bit different than the Postgres and MySQL cases. You can qualify a table name with `foo.table` in SQLite, but rather than identify a schema `foo` this identifies a database `foo`.

But SQLite databases are more like Postgres schemas than they are like Postgres databases. You can join across SQLite databases, for instance. Though you can't enforce a fkey constraint across databases.

The other weird thing about SQLite databases is that the command that creates a database needs a reference to a file (or URI or whatever), whereas in Postgres and MySQL you just need the name of the schema. So in order to actually make use of Persistent's schema support with SQLite, the user will need to issue an `attach 'foo.db' as foo;` command. We'll need to document this as part of how the feature works.