### PR TITLE
Second pass at postgres

### DIFF
--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -9,8 +9,8 @@ import Init
 
 share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [persistLowerCase|
 SchemaEntity schema=foo
-    foo Int
-    Primary foo
+    bar Int
+    Primary bar
 |]
 
 cleanDB
@@ -31,10 +31,10 @@ specsWith runConn = describe "entity with non-null schema" $
         -- Ensure we can write to the database
         x <- insert $
             SchemaEntity
-                { schemaEntityFoo = 42
+                { schemaEntityBar = 42
                 }
         Just schemaEntity <- get x
-        rawFoo  <- rawSql "SELECT foo FROM foo.schema_entity" []
-        liftIO $ rawFoo @?= [Single (42 :: Int)]
-        liftIO $ schemaEntityFoo schemaEntity @== 42
+        rawBar  <- rawSql "SELECT bar FROM foo.schema_entity" []
+        liftIO $ rawBar @?= [Single (42 :: Int)]
+        liftIO $ schemaEntityBar schemaEntity @== 42
         return ()

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -36,4 +36,5 @@ specsWith runConn = describe "entity with non-null schema" $
         Just schemaEntity <- get x
         rawFoo  <- rawSql "SELECT foo FROM foo.schema_entity" []
         liftIO $ rawFoo @?= [Single (42 :: Int)]
+        liftIO $ schemaEntityFoo schemaEntity @== 42
         return ()


### PR DESCRIPTION
I realized that if you run the test suite twice, it starts to break due to repeated CREATe TABLE ... commands.

The root cause is because we were escaping the schema name in places where we shouldn't escape it. Escaping the name is proper when you are using it as a SQL relation name, but when you are trying to pass the value around as a string it needs to remain unescaped.
